### PR TITLE
Serialize the doc.metadata.log instead of deletign all metadata

### DIFF
--- a/server/api/ingest.ts
+++ b/server/api/ingest.ts
@@ -17,9 +17,9 @@ const upsertDocsToVectorstore = async (
   const ids = [];
   const encoder = new TextEncoder();
   for (const doc of docs) {
-    // Vectorize does not support object metadata, and we won't be needing it for
-    // this app.
-    doc.metadata = {};
+    if (doc.metadata?.loc) {
+      doc.metadata.loc = JSON.stringify(doc.metadata.loc);
+    }
     const insecureHash = await crypto.subtle.digest(
       "SHA-1",
       encoder.encode(doc.pageContent),


### PR DESCRIPTION

Metadata is supported, but metadata.loc is being passed as an [object] and that's breaking the request. You can delete metadata.loc or serialize it as a string.

PR incoming